### PR TITLE
Add version code to Application class

### DIFF
--- a/lib/device_apps.dart
+++ b/lib/device_apps.dart
@@ -82,6 +82,7 @@ class Application {
   final String appName;
   final String packageName;
   final String versionName;
+  final int versionCode;
   final String dataDir;
   final bool systemApp;
 
@@ -101,17 +102,19 @@ class Application {
       : assert(map['app_name'] != null),
         assert(map['package_name'] != null),
         assert(map['version_name'] != null),
+        assert(map['version_code'] != null),
         assert(map['data_dir'] != null),
         assert(map['system_app'] != null),
         appName = map['app_name'],
         packageName = map['package_name'],
         versionName = map['version_name'],
+        versionCode = map['version_code'],
         dataDir = map['data_dir'],
         systemApp = map['system_app'];
 
   @override
   String toString() {
-    return 'App name: $appName, Package name: $packageName, Version name: $versionName';
+    return 'App name: $appName, Package name: $packageName, Version name: $versionName, Version code: $versionCode';
   }
 }
 


### PR DESCRIPTION
You get version code in plugin, but don't use it later in Application constructor

```
private Map<String, Object> getAppData(PackageManager packageManager, PackageInfo pInfo, boolean includeAppIcon) {

map.put("version_code", pInfo.versionCode);
        map.put("version_name", pInfo.versionName);
```

```
Application._fromMap(Map map)

versionName = map['version_name'],
```