### PR TITLE
Add APK file path to Application class

### DIFF
--- a/android/src/main/java/fr/g123k/deviceapps/DeviceAppsPlugin.java
+++ b/android/src/main/java/fr/g123k/deviceapps/DeviceAppsPlugin.java
@@ -171,6 +171,7 @@ public class DeviceAppsPlugin implements MethodCallHandler, PluginRegistry.ViewD
     private Map<String, Object> getAppData(PackageManager packageManager, PackageInfo pInfo, boolean includeAppIcon) {
         Map<String, Object> map = new HashMap<>();
         map.put("app_name", pInfo.applicationInfo.loadLabel(packageManager).toString());
+        map.put("apk_file_path", pInfo.applicationInfo.sourceDir);
         map.put("package_name", pInfo.packageName);
         map.put("version_code", pInfo.versionCode);
         map.put("version_name", pInfo.versionName);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -82,7 +82,7 @@ class _ListAppsPagesContent extends StatelessWidget {
                           onTap: () => DeviceApps.openApp(app.packageName),
                           title: Text("${app.appName} (${app.packageName})"),
                           subtitle: Text(
-                              "Version: ${app.versionName}\nSystem app: ${app.systemApp}\nData dir : ${app.dataDir}")),
+                              "Version: ${app.versionName}\nSystem app: ${app.systemApp}\nData dir : ${app.dataDir}\nAPK file path: ${app.apkFilePath}")),
                       Divider(
                         height: 1.0,
                       )

--- a/lib/device_apps.dart
+++ b/lib/device_apps.dart
@@ -80,6 +80,7 @@ class DeviceApps {
 
 class Application {
   final String appName;
+  final String apkFilePath;
   final String packageName;
   final String versionName;
   final int versionCode;
@@ -100,12 +101,14 @@ class Application {
 
   Application._fromMap(Map map)
       : assert(map['app_name'] != null),
+        assert(map['apk_file_path'] != null),
         assert(map['package_name'] != null),
         assert(map['version_name'] != null),
         assert(map['version_code'] != null),
         assert(map['data_dir'] != null),
         assert(map['system_app'] != null),
         appName = map['app_name'],
+        apkFilePath = map['apk_file_path'],
         packageName = map['package_name'],
         versionName = map['version_name'],
         versionCode = map['version_code'],


### PR DESCRIPTION
I've added code to get the absolute file path to the APK file of an installed app on the device. 

On a side note; I don't think extracting IPA's is possible on IOS without jailbreak, so if you still plan to add support for IOS and think this feature is a bit out of scope, I won't mind if you reject this pull request.