### PR TITLE
Null safety support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## [2.0.0] - 06th March 2021
+
+* Null safety support
+
 ## [1.3.0] - 06th March 2021
 
 * New feature: listen to app changes (installation, uninstallation, updates…)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A plugin to list installed applications on an Android device (⚠️ iOS is not 
 
 ## Change with Android 11
 
-Starting with Android 11, Android applications targeting API level 30, willing to list "external" applications have to declare a new "normal" permission in their `AndroidManifest.xml` file called [`QUERY_ALL_PACKAGES`](https://developer.android.com/reference/kotlin/android/Manifest.permission#query_all_packages). A few notes about this: 
+Starting with Android 11, Android applications targeting API level 30, willing to list "external" applications have to declare a new "normal" permission in their `AndroidManifest.xml` file called [`QUERY_ALL_PACKAGES`](https://developer.android.com/reference/kotlin/android/Manifest.permission#query_all_packages). A few notes about this:
 
 - A normal permission doesn't require the user consent
 - Don't worry, this plugin automatically adds the permission for you
@@ -20,6 +20,7 @@ However, publishing applications on the Google Play with this kind of feature **
 ## Getting Started
 
 First, you have to import the package in your dart file with:
+
 ```dart
 import 'package:device_apps/device_apps.dart';
 ```
@@ -37,6 +38,7 @@ You can filter system apps if necessary.
 **Note**: The list of apps is not ordered! You have to do it yourself.
 
 ### Get apps with a launch Intent
+
 A launch Intent means you can launch the application.
 
 To list only the apps with launch intents, simply use the `onlyAppsWithLaunchIntent: true` attribute.
@@ -45,7 +47,6 @@ To list only the apps with launch intents, simply use the `onlyAppsWithLaunchInt
 // Returns a list of only those apps that have launch intent
 List<Application> apps = await DeviceApps.getInstalledApplications(onlyAppsWithLaunchIntent: true, includeSystemApps: true)
 ```
-
 
 ## Get an application
 
@@ -66,6 +67,7 @@ bool isInstalled = await DeviceApps.isAppInstalled('com.frandroid.app');
 ## Open an application
 
 To open an application (with a launch Intent)
+
 ```dart
 DeviceApps.openApp('com.frandroid.app');
 ```
@@ -73,6 +75,7 @@ DeviceApps.openApp('com.frandroid.app');
 ## Open an application settings screen
 
 To open an application settings screen
+
 ```dart
 DeviceApps.openAppSettings('com.frandroid.app');
 ```

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -4,14 +4,14 @@
 // find child widgets in the widget tree, read text, and verify that the values of widget properties
 // are correct.
 
-import 'package:device_apps_example/main.dart';
+import 'package:device_apps_example/apps_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Verify Platform version', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(ListAppsPages());
+    await tester.pumpWidget(AppsListScreen());
 
     // Verify that platform version is retrieved.
     expect(

--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -55,11 +55,11 @@ class DeviceApps {
         }
         return list;
       } else {
-        return <Application>[];
+        return List<Application>.empty();
       }
     } catch (err) {
       print(err);
-      return <Application>[];
+      return List<Application>.empty();
     }
   }
 

--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -211,7 +211,7 @@ class Application extends _BaseApplication {
   /// [https://developer.android.com/reference/kotlin/android/content/pm/ApplicationInfo]
   /// [category] is null on Android < 26
   static ApplicationCategory _parseCategory(Object? category) {
-    if (category == null || (category is num && category < 0)) {
+    if (category is num && category < 0) {
       return ApplicationCategory.undefined;
     } else if (category == 0) {
       return ApplicationCategory.game;

--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -115,11 +115,7 @@ class DeviceApps {
       throw Exception('The package name can not be empty');
     }
     return await (_methodChannel.invokeMethod(
-      'openApp',
-      <String, String>{
-        'package_name': packageName,
-      },
-    ) as FutureOr<bool>);
+        'openApp', <String, String>{'package_name': packageName}));
   }
 
   /// Launch the Settings screen of the app based on its [packageName]
@@ -131,11 +127,7 @@ class DeviceApps {
     }
 
     return await (_methodChannel.invokeMethod(
-      'openAppSettings',
-      <String, String>{
-        'package_name': packageName,
-      },
-    ) as FutureOr<bool>);
+        'openAppSettings', <String, String>{'package_name': packageName}));
   }
 
   /// Listen to app changes: installations, uninstallations, updates, enabled or
@@ -144,9 +136,10 @@ class DeviceApps {
   static Stream<ApplicationEvent> listenToAppsChanges() {
     return _eventChannel
         .receiveBroadcastStream()
-        .map(((dynamic event) =>
-            ApplicationEvent._(event as Map<Object, Object>)))
-        .handleError((Object err) => null);
+        .map(((Object event) =>
+                ApplicationEvent._(event as Map<Object, Object>))
+            as Function(dynamic))
+        .handleError((Object err) => null) as Stream<ApplicationEvent>;
   }
 }
 
@@ -195,7 +188,7 @@ class Application extends _BaseApplication {
 
   /// Whether the app is enabled (installed and visible)
   /// or disabled (installed, but not visible)
-  final bool? enabled;
+  final bool enabled;
 
   factory Application._(Map<Object, Object> map) {
     if (map.length == 0) {
@@ -217,7 +210,7 @@ class Application extends _BaseApplication {
         systemApp = map['system_app'] as bool,
         installTimeMillis = map['install_time'] as int,
         updateTimeMillis = map['update_time'] as int,
-        enabled = map['is_enabled'] as bool?,
+        enabled = map['is_enabled'] as bool,
         category = _parseCategory(map['category']),
         super._fromMap(map);
 

--- a/lib/src/plugin.dart
+++ b/lib/src/plugin.dart
@@ -30,14 +30,12 @@ class DeviceApps {
     bool onlyAppsWithLaunchIntent: false,
   }) async {
     try {
-      final Object apps = await _methodChannel.invokeMethod(
-        'getInstalledApps',
-        <String, bool>{
-          'system_apps': includeSystemApps,
-          'include_app_icons': includeAppIcons,
-          'only_apps_with_launch_intent': onlyAppsWithLaunchIntent,
-        },
-      );
+      final Object apps =
+          await _methodChannel.invokeMethod('getInstalledApps', <String, bool>{
+        'system_apps': includeSystemApps,
+        'include_app_icons': includeAppIcons,
+        'only_apps_with_launch_intent': onlyAppsWithLaunchIntent
+      });
       if (apps is Iterable<Object>) {
         List<Application> list = <Application>[];
         for (Object app in apps) {
@@ -75,12 +73,10 @@ class DeviceApps {
     }
     try {
       final Object? app = await _methodChannel.invokeMethod(
-        'getApp',
-        <String, Object>{
-          'package_name': packageName,
-          'include_app_icon': includeAppIcon,
-        },
-      );
+          'getApp', <String, Object>{
+        'package_name': packageName,
+        'include_app_icon': includeAppIcon
+      });
       if (app != null && app is Map<Object, Object>) {
         return Application._(app);
       } else {
@@ -99,11 +95,8 @@ class DeviceApps {
       throw Exception('The package name can not be empty');
     }
     return _methodChannel.invokeMethod(
-      'isAppInstalled',
-      <String, String>{
-        'package_name': packageName,
-      },
-    ) as Future<bool>;
+            'isAppInstalled', <String, String>{'package_name': packageName})
+        as Future<bool>;
   }
 
   /// Launch an app based on its [packageName]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,10 @@ description: Plugin to list applications installed on an Android device (iOS is 
 version: 1.3.0
 homepage: https://github.com/g123k/flutter_plugin_device_apps
 
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: ">=1.10.0"
+
 dependencies:
   flutter:
     sdk: flutter
@@ -13,7 +17,3 @@ flutter:
       android:
         package: fr.g123k.deviceapps
         pluginClass: DeviceAppsPlugin
-
-environment:
-  sdk: ">=2.0.0 <3.0.0"
-  flutter: ">=1.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_apps
 description: Plugin to list applications installed on an Android device (iOS is not supported). You can also monitor application changes (updates, uninstallation…)
-version: 1.3.0
+version: 2.0.0
 homepage: https://github.com/g123k/flutter_plugin_device_apps
 
 environment:


### PR DESCRIPTION
In some functions I used the syntax `async / await` instead of `then` because I think the code is easier to understand that way.

Review your Java code to see in which cases `null` was never returned.

Fix #63 