### PR TITLE
Support lazy loading through `DeviceApps.streamInstalledApplications()`

### DIFF
--- a/android/src/main/java/fr/g123k/deviceapps/listener/DeviceAppsChangedListener.java
+++ b/android/src/main/java/fr/g123k/deviceapps/listener/DeviceAppsChangedListener.java
@@ -15,7 +15,7 @@ import io.flutter.plugin.common.EventChannel;
 public class DeviceAppsChangedListener {
 
     private final DeviceAppsChangedListenerInterface callback;
-    private Set<EventChannel.EventSink> eventSink;
+    private EventChannel.EventSink eventSink;
 
     private BroadcastReceiver appsBroadcastReceiver;
 
@@ -25,7 +25,7 @@ public class DeviceAppsChangedListener {
     }
 
     public void register(@NonNull Context context, EventChannel.EventSink events) {
-        unregister();
+        unregister(context);
 
         if (appsBroadcastReceiver == null) {
             createBroadcastReceiver();


### PR DESCRIPTION
## Lazy loading through new API `streamInstalledApplications`

With this PR there's an way to use this package to list all packages individually; how and why was explained on #89.

Take this for instance:

```dart
final apps = <Application>[];
final appsStream = DeviceApps.streamInstalledApplications(
  includeAppIcons: true,
  includeSystemApps: true,
);

appsStream.listen(
  (app) {
    apps.add(app);
    setState(() {});
  },
  onDone: () {
    isLoading = false;
    setState(() {});
  },
);
```

The example above will updated the Flutter UI every time a new package is loaded in the native side, instead of:

```dart
// This call takes 5~10 seconds in real devices with large apps data set
// Meanwhile a boring loading spinner should be shown
final apps = await DeviceApps.getInstalledApplications(
  includeAppIcons: true,
  includeSystemApps: true,
);
setState(() {}); 
```

## `getInstalledApplications` propose

We can also re-implement the `getInstalledApplications` API since the `Stream<T>`s can be converted to `Future<T>`s (but not vice-versa).

```dart
static Future<List<Application>> getInstalledApplications({
  bool includeSystemApps: false,
  bool includeAppIcons: false,
  bool onlyAppsWithLaunchIntent: false,
}) async {
  return streamInstalledApplications().toList(); // Re-use the logic here and convert as Future<T>
}
```

This PR is a scratch, I would to know what we can change here to improve even more this feature.