### PR TITLE
Add namespace to build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 30
+    namespace "fr.g123k.deviceapps"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Fix for this error:

````Task failed with an exception.
-----------
* What went wrong:
A problem occurred configuring project ':device_apps'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Failed to query the value of property 'buildFlowServiceProperty'.
> Could not isolate value org.jetbrains.kotlin.gradle.plugin.statistics.BuildFlowService$Parameters_Decorated@59b82877 of type BuildFlowService.Parameters
   > A problem occurred configuring project ':device_apps'.
      > Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
         > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

           If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

````

https://developer.android.com/build/configure-app-module#set-namespace